### PR TITLE
fix: set min python version to 3.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ This server exposes all Polygon.io API endpoints as MCP tools, providing access 
 
 ### Prerequisites
 
-- Python 3.8+
+- Python 3.10+
 - A Polygon.io API key <br> [![Button]][Link]
 - [Astral UV](https://docs.astral.sh/uv/getting-started/installation/)
   - For existing installs, check that you have a version that supports the `uvx` command.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "mcp_polygon"
 version = "0.1.0"
 description = "A MCP server project"
 readme = "README.md"
-requires-python = ">=3.13"
+requires-python = ">=3.10"
 dependencies = [
  "mcp[cli]>=1.4.1",
  "polygon-api-client>=1.14.4",

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,6 @@
 version = 1
 revision = 1
-requires-python = ">=3.13"
+requires-python = ">=3.10"
 
 [[package]]
 name = "annotated-types"


### PR DESCRIPTION
# Description
Unify the python min version to the minimum required by the MCP framework.

Closes #3 