### PR TITLE
Update claude code instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ path to `uvx`.
 
 ```bash
 # Claude CLI
-claude mcp add polygon -e POLYGON_API_KEY=your_api_key_here -- uvx --from git+https://github.com/polygon-io/mcp_polygon@master mcp_polygon
+claude mcp add polygon -e POLYGON_API_KEY=your_api_key_here -- uvx --from git+https://github.com/polygon-io/mcp_polygon@v0.1.0 mcp_polygon
 ```
 
 This command will install the MCP server in your current project.
@@ -81,7 +81,7 @@ Make sure you complete the various fields.
             "command": "<path_to_your_uvx_install>/uvx",
             "args": [
                 "--from",
-                "git+https://github.com/polygon-io/mcp_polygon@master",
+                "git+https://github.com/polygon-io/mcp_polygon@v0.1.0",
                 "mcp_polygon"
             ],
             "env": {

--- a/README.md
+++ b/README.md
@@ -45,11 +45,14 @@ npm install -g @anthropic-ai/claude-code
 ```
 
 Use the following command to add the Polygon MCP server to your local environment.
+This assumes `uvx` is in your $PATH; if not, then you need to provide the full
+path to `uvx`.
 
 ```bash
 # Claude CLI
-claude mcp add polygon -e POLYGON_API_KEY=your_api_key_here -- uv run /path/to/mcp_polygon/entrypoint.py
+claude mcp add polygon -e POLYGON_API_KEY=your_api_key_here -- uvx --from git+https://github.com/polygon-io/mcp_polygon@master mcp_polygon
 ```
+
 This command will install the MCP server in your current project.
 If you want to install it globally, you can run the command with `-s <scope>` flag.
 See `claude mcp add --help` for more options.


### PR DESCRIPTION
The instructions for running this MCP server with Claude Code required the user to have cloned the repo first. Instead we can offer a similar configuration as the one for Claude Desktop.