### PR TITLE
Lint pull requests and add just recipe

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+name: Validate Code Quality
+
+permissions:
+  contents: read
+  pull-requests: write
+
+on:
+  pull_request:
+    branches:
+      - 'master'
+
+jobs:
+  lint:
+    name: Code Quality & Testing
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install UV
+        uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version-file: "pyproject.toml"
+
+      - name: Install dependencies
+        run: uv sync
+
+      - name: Run Ruff check
+        run: uv ruff check
+
+      - name: Run Ruff format
+        run: uv ruff format --check

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ build/
 dist/
 wheels/
 *.egg-info
+.ruff-cache/
 
 # Virtual environments
 .venv

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 </a>
 <br>
 
-> [!IMPORTANT]  
+> [!IMPORTANT]
 > :test_tube: This project is experimental and could be subject to breaking changes.
 
 # Polygon.io MCP Server
@@ -65,7 +65,7 @@ You can also run `claude mcp add-from-claude-desktop` if the MCP server is insta
 ### Claude Desktop
 
 1. Follow the [Claude Desktop MCP installation instructions](https://modelcontextprotocol.io/quickstart/user) to complete the initial installation and find your configuration file.
-1. Use the following example as reference to add Polygon's MCP server. 
+1. Use the following example as reference to add Polygon's MCP server.
 Make sure you complete the various fields.
     1. Path find your path to `uvx`, run `which uvx` in your terminal.
     2. Replace `<your_api_key_here>` with your actual Polygon.io API key.
@@ -181,15 +181,25 @@ npx @modelcontextprotocol/inspector uv --directory /path/to/mcp_polygon run mcp_
 
 This will launch a browser interface where you can interact with your MCP server directly and see input/output for each tool.
 
+### Code Linting
+
+This project uses [just](https://github.com/casey/just) for common development tasks. To lint your code before submitting a PR:
+
+```bash
+just lint
+```
+
+This will run `ruff format` and `ruff check --fix` to automatically format your code and fix linting issues.
+
 ## Links
 - [Polygon.io Documentation](https://polygon.io/docs?utm_campaign=mcp&utm_medium=referral&utm_source=github)
 - [Model Context Protocol](https://modelcontextprotocol.io)
 - [MCP Python SDK](https://github.com/modelcontextprotocol/python-sdk)
 
 ## Contributing
-If you found a bug or have an idea for a new feature, please first discuss it with us by submitting a new issue. 
-We will respond to issues within at most 3 weeks. 
-We're also open to volunteers if you want to submit a PR for any open issues but please discuss it with us beforehand. 
+If you found a bug or have an idea for a new feature, please first discuss it with us by submitting a new issue.
+We will respond to issues within at most 3 weeks.
+We're also open to volunteers if you want to submit a PR for any open issues but please discuss it with us beforehand.
 PRs that aren't linked to an existing issue or discussed with us ahead of time will generally be declined.
 
 <!----------------------------------------------------------------------------->

--- a/entrypoint.py
+++ b/entrypoint.py
@@ -1,6 +1,25 @@
 #!/usr/bin/env python
 import os
+from typing import Literal
 from mcp_polygon import server
+
+
+def transport() -> Literal["stdio", "sse", "streamable-http"]:
+    """
+    Determine the transport type for the MCP server.
+    Defaults to 'stdio' if not set in environment variables.
+    """
+    mcp_transport_str = os.environ.get("MCP_TRANSPORT", "stdio")
+
+    # These are currently the only supported transports
+    supported_transports: dict[str, Literal["stdio", "sse", "streamable-http"]] = {
+        "stdio": "stdio",
+        "sse": "sse",
+        "streamable-http": "streamable-http",
+    }
+
+    return supported_transports.get(mcp_transport_str, "stdio")
+
 
 # Ensure the server process doesn't exit immediately when run as an MCP server
 def start_server():
@@ -10,9 +29,8 @@ def start_server():
     else:
         print("Starting Polygon MCP server with API key configured.")
 
-    mcp_transport = os.environ.get("MCP_TRANSPORT") or "stdio"
+    server.run(transport=transport())
 
-    server.run(mcp_transport)
 
 if __name__ == "__main__":
     start_server()

--- a/justfile
+++ b/justfile
@@ -1,0 +1,3 @@
+lint:
+    uv run ruff format
+    uv run ruff check --fix

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,5 +16,10 @@ email = "support@polygon.io"
 requires = [ "hatchling",]
 build-backend = "hatchling.build"
 
+[dependency-groups]
+dev = [
+    "ruff>=0.12.4",
+]
+
 [project.scripts]
 mcp_polygon = "mcp_polygon:run"

--- a/src/mcp_polygon/__init__.py
+++ b/src/mcp_polygon/__init__.py
@@ -1,3 +1,3 @@
 from .server import run
 
-__all__ = ['run']
+__all__ = ["run"]

--- a/src/mcp_polygon/server.py
+++ b/src/mcp_polygon/server.py
@@ -1,6 +1,6 @@
 import os
 import json
-from typing import Optional, Any, Dict, Union, List
+from typing import Optional, Any, Dict, Union, List, Literal
 from mcp.server.fastmcp import FastMCP
 from polygon import RESTClient
 from importlib.metadata import version, PackageNotFoundError
@@ -22,18 +22,19 @@ polygon_client.headers["User-Agent"] += f" {version_number}"
 
 poly_mcp = FastMCP("Polygon", dependencies=["polygon"])
 
+
 @poly_mcp.tool()
 async def get_aggs(
-        ticker: str,
-        multiplier: int,
-        timespan: str,
-        from_: Union[str, int, datetime, date],
-        to: Union[str, int, datetime, date],
-        adjusted: Optional[bool] = None,
-        sort: Optional[str] = None,
-        limit: Optional[int] = None,
-        params: Optional[Dict[str, Any]] = None,
-    ) -> Dict[str, Any]:
+    ticker: str,
+    multiplier: int,
+    timespan: str,
+    from_: Union[str, int, datetime, date],
+    to: Union[str, int, datetime, date],
+    adjusted: Optional[bool] = None,
+    sort: Optional[str] = None,
+    limit: Optional[int] = None,
+    params: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
     """
     List aggregate bars for a ticker over a given date range in custom time window sizes.
     """
@@ -48,27 +49,28 @@ async def get_aggs(
             sort=sort,
             limit=limit,
             params=params,
-            raw=True
+            raw=True,
         )
-        
+
         # Parse the binary data to string and then to JSON
-        data_str = results.data.decode('utf-8')
+        data_str = results.data.decode("utf-8")
         return json.loads(data_str)
     except Exception as e:
         return {"error": str(e)}
 
+
 @poly_mcp.tool()
 async def list_aggs(
-        ticker: str,
-        multiplier: int,
-        timespan: str,
-        from_: Union[str, int, datetime, date],
-        to: Union[str, int, datetime, date],
-        adjusted: Optional[bool] = None,
-        sort: Optional[str] = None,
-        limit: Optional[int] = None,
-        params: Optional[Dict[str, Any]] = None,
-    ) -> Dict[str, Any]:
+    ticker: str,
+    multiplier: int,
+    timespan: str,
+    from_: Union[str, int, datetime, date],
+    to: Union[str, int, datetime, date],
+    adjusted: Optional[bool] = None,
+    sort: Optional[str] = None,
+    limit: Optional[int] = None,
+    params: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
     """
     Iterate through aggregate bars for a ticker over a given date range.
     """
@@ -83,23 +85,24 @@ async def list_aggs(
             sort=sort,
             limit=limit,
             params=params,
-            raw=True
+            raw=True,
         )
-        
-        data_str = results.data.decode('utf-8')
+
+        data_str = results.data.decode("utf-8")
         return json.loads(data_str)
     except Exception as e:
         return {"error": str(e)}
 
+
 @poly_mcp.tool()
 async def get_grouped_daily_aggs(
-        date: str,
-        adjusted: Optional[bool] = None,
-        include_otc: Optional[bool] = None,
-        locale: Optional[str] = None,
-        market_type: Optional[str] = None,
-        params: Optional[Dict[str, Any]] = None,
-    ) -> Dict[str, Any]:
+    date: str,
+    adjusted: Optional[bool] = None,
+    include_otc: Optional[bool] = None,
+    locale: Optional[str] = None,
+    market_type: Optional[str] = None,
+    params: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
     """
     Get grouped daily bars for entire market for a specific date.
     """
@@ -111,73 +114,69 @@ async def get_grouped_daily_aggs(
             locale=locale,
             market_type=market_type,
             params=params,
-            raw=True
+            raw=True,
         )
-        
-        data_str = results.data.decode('utf-8')
+
+        data_str = results.data.decode("utf-8")
         return json.loads(data_str)
     except Exception as e:
         return {"error": str(e)}
 
+
 @poly_mcp.tool()
 async def get_daily_open_close_agg(
-        ticker: str,
-        date: str,
-        adjusted: Optional[bool] = None,
-        params: Optional[Dict[str, Any]] = None,
-    ) -> Dict[str, Any]:
+    ticker: str,
+    date: str,
+    adjusted: Optional[bool] = None,
+    params: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
     """
     Get daily open, close, high, and low for a specific ticker and date.
     """
     try:
         results = polygon_client.get_daily_open_close_agg(
-            ticker=ticker,
-            date=date,
-            adjusted=adjusted,
-            params=params,
-            raw=True
+            ticker=ticker, date=date, adjusted=adjusted, params=params, raw=True
         )
-        
-        data_str = results.data.decode('utf-8')
+
+        data_str = results.data.decode("utf-8")
         return json.loads(data_str)
     except Exception as e:
         return {"error": str(e)}
 
+
 @poly_mcp.tool()
 async def get_previous_close_agg(
-        ticker: str,
-        adjusted: Optional[bool] = None,
-        params: Optional[Dict[str, Any]] = None,
-    ) -> Dict[str, Any]:
+    ticker: str,
+    adjusted: Optional[bool] = None,
+    params: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
     """
     Get previous day's open, close, high, and low for a specific ticker.
     """
     try:
         results = polygon_client.get_previous_close_agg(
-            ticker=ticker,
-            adjusted=adjusted,
-            params=params,
-            raw=True
+            ticker=ticker, adjusted=adjusted, params=params, raw=True
         )
-        
-        data_str = results.data.decode('utf-8')
+
+        data_str = results.data.decode("utf-8")
         return json.loads(data_str)
     except Exception as e:
         return {"error": str(e)}
 
+
 @poly_mcp.tool()
 async def list_trades(
-        ticker: str,
-        timestamp: Optional[Union[str, int, datetime, date]] = None,
-        timestamp_lt: Optional[Union[str, int, datetime, date]] = None,
-        timestamp_lte: Optional[Union[str, int, datetime, date]] = None,
-        timestamp_gt: Optional[Union[str, int, datetime, date]] = None,
-        timestamp_gte: Optional[Union[str, int, datetime, date]] = None,
-        limit: Optional[int] = None,
-        sort: Optional[str] = None,
-        order: Optional[str] = None,
-        params: Optional[Dict[str, Any]] = None,
-    ) -> Dict[str, Any]:
+    ticker: str,
+    timestamp: Optional[Union[str, int, datetime, date]] = None,
+    timestamp_lt: Optional[Union[str, int, datetime, date]] = None,
+    timestamp_lte: Optional[Union[str, int, datetime, date]] = None,
+    timestamp_gt: Optional[Union[str, int, datetime, date]] = None,
+    timestamp_gte: Optional[Union[str, int, datetime, date]] = None,
+    limit: Optional[int] = None,
+    sort: Optional[str] = None,
+    order: Optional[str] = None,
+    params: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
     """
     Get trades for a ticker symbol.
     """
@@ -193,69 +192,65 @@ async def list_trades(
             sort=sort,
             order=order,
             params=params,
-            raw=True
+            raw=True,
         )
-        
-        data_str = results.data.decode('utf-8')
+
+        data_str = results.data.decode("utf-8")
         return json.loads(data_str)
     except Exception as e:
         return {"error": str(e)}
 
+
 @poly_mcp.tool()
 async def get_last_trade(
-        ticker: str,
-        params: Optional[Dict[str, Any]] = None,
-    ) -> Dict[str, Any]:
+    ticker: str,
+    params: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
     """
     Get the most recent trade for a ticker symbol.
     """
     try:
-        results = polygon_client.get_last_trade(
-            ticker=ticker,
-            params=params,
-            raw=True
-        )
-        
-        data_str = results.data.decode('utf-8')
+        results = polygon_client.get_last_trade(ticker=ticker, params=params, raw=True)
+
+        data_str = results.data.decode("utf-8")
         return json.loads(data_str)
     except Exception as e:
         return {"error": str(e)}
 
+
 @poly_mcp.tool()
 async def get_last_crypto_trade(
-        from_: str,
-        to: str,
-        params: Optional[Dict[str, Any]] = None,
-    ) -> Dict[str, Any]:
+    from_: str,
+    to: str,
+    params: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
     """
     Get the most recent trade for a crypto pair.
     """
     try:
         results = polygon_client.get_last_crypto_trade(
-            from_=from_,
-            to=to,
-            params=params,
-            raw=True
+            from_=from_, to=to, params=params, raw=True
         )
-        
-        data_str = results.data.decode('utf-8')
+
+        data_str = results.data.decode("utf-8")
         return json.loads(data_str)
     except Exception as e:
         return {"error": str(e)}
 
+
 @poly_mcp.tool()
 async def list_quotes(
-        ticker: str,
-        timestamp: Optional[Union[str, int, datetime, date]] = None,
-        timestamp_lt: Optional[Union[str, int, datetime, date]] = None,
-        timestamp_lte: Optional[Union[str, int, datetime, date]] = None,
-        timestamp_gt: Optional[Union[str, int, datetime, date]] = None,
-        timestamp_gte: Optional[Union[str, int, datetime, date]] = None,
-        limit: Optional[int] = None,
-        sort: Optional[str] = None,
-        order: Optional[str] = None,
-        params: Optional[Dict[str, Any]] = None,
-    ) -> Dict[str, Any]:
+    ticker: str,
+    timestamp: Optional[Union[str, int, datetime, date]] = None,
+    timestamp_lt: Optional[Union[str, int, datetime, date]] = None,
+    timestamp_lte: Optional[Union[str, int, datetime, date]] = None,
+    timestamp_gt: Optional[Union[str, int, datetime, date]] = None,
+    timestamp_gte: Optional[Union[str, int, datetime, date]] = None,
+    limit: Optional[int] = None,
+    sort: Optional[str] = None,
+    order: Optional[str] = None,
+    params: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
     """
     Get quotes for a ticker symbol.
     """
@@ -271,64 +266,60 @@ async def list_quotes(
             sort=sort,
             order=order,
             params=params,
-            raw=True
+            raw=True,
         )
-        
-        data_str = results.data.decode('utf-8')
+
+        data_str = results.data.decode("utf-8")
         return json.loads(data_str)
     except Exception as e:
         return {"error": str(e)}
 
+
 @poly_mcp.tool()
 async def get_last_quote(
-        ticker: str,
-        params: Optional[Dict[str, Any]] = None,
-    ) -> Dict[str, Any]:
+    ticker: str,
+    params: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
     """
     Get the most recent quote for a ticker symbol.
     """
     try:
-        results = polygon_client.get_last_quote(
-            ticker=ticker,
-            params=params,
-            raw=True
-        )
-        
-        data_str = results.data.decode('utf-8')
+        results = polygon_client.get_last_quote(ticker=ticker, params=params, raw=True)
+
+        data_str = results.data.decode("utf-8")
         return json.loads(data_str)
     except Exception as e:
         return {"error": str(e)}
 
+
 @poly_mcp.tool()
 async def get_last_forex_quote(
-        from_: str,
-        to: str,
-        params: Optional[Dict[str, Any]] = None,
-    ) -> Dict[str, Any]:
+    from_: str,
+    to: str,
+    params: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
     """
     Get the most recent forex quote.
     """
     try:
         results = polygon_client.get_last_forex_quote(
-            from_=from_,
-            to=to,
-            params=params,
-            raw=True
+            from_=from_, to=to, params=params, raw=True
         )
-        
-        data_str = results.data.decode('utf-8')
+
+        data_str = results.data.decode("utf-8")
         return json.loads(data_str)
     except Exception as e:
         return {"error": str(e)}
 
+
 @poly_mcp.tool()
 async def get_real_time_currency_conversion(
-        from_: str,
-        to: str,
-        amount: Optional[float] = None,
-        precision: Optional[int] = None,
-        params: Optional[Dict[str, Any]] = None,
-    ) -> Dict[str, Any]:
+    from_: str,
+    to: str,
+    amount: Optional[float] = None,
+    precision: Optional[int] = None,
+    params: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
     """
     Get real-time currency conversion.
     """
@@ -339,23 +330,24 @@ async def get_real_time_currency_conversion(
             amount=amount,
             precision=precision,
             params=params,
-            raw=True
+            raw=True,
         )
-        
-        data_str = results.data.decode('utf-8')
+
+        data_str = results.data.decode("utf-8")
         return json.loads(data_str)
     except Exception as e:
         return {"error": str(e)}
 
+
 @poly_mcp.tool()
 async def list_universal_snapshots(
-        type: str,
-        ticker_any_of: Optional[List[str]] = None,
-        order: Optional[str] = None,
-        limit: Optional[int] = None,
-        sort: Optional[str] = None,
-        params: Optional[Dict[str, Any]] = None,
-    ) -> Dict[str, Any]:
+    type: str,
+    ticker_any_of: Optional[List[str]] = None,
+    order: Optional[str] = None,
+    limit: Optional[int] = None,
+    sort: Optional[str] = None,
+    params: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
     """
     Get universal snapshots for multiple assets of a specific type.
     """
@@ -367,21 +359,22 @@ async def list_universal_snapshots(
             limit=limit,
             sort=sort,
             params=params,
-            raw=True
+            raw=True,
         )
-        
-        data_str = results.data.decode('utf-8')
+
+        data_str = results.data.decode("utf-8")
         return json.loads(data_str)
     except Exception as e:
         return {"error": str(e)}
 
+
 @poly_mcp.tool()
 async def get_snapshot_all(
-        market_type: str,
-        tickers: Optional[List[str]] = None,
-        include_otc: Optional[bool] = None,
-        params: Optional[Dict[str, Any]] = None,
-    ) -> Dict[str, Any]:
+    market_type: str,
+    tickers: Optional[List[str]] = None,
+    include_otc: Optional[bool] = None,
+    params: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
     """
     Get a snapshot of all tickers in a market.
     """
@@ -391,21 +384,22 @@ async def get_snapshot_all(
             tickers=tickers,
             include_otc=include_otc,
             params=params,
-            raw=True
+            raw=True,
         )
-        
-        data_str = results.data.decode('utf-8')
+
+        data_str = results.data.decode("utf-8")
         return json.loads(data_str)
     except Exception as e:
         return {"error": str(e)}
 
+
 @poly_mcp.tool()
 async def get_snapshot_direction(
-        market_type: str,
-        direction: str,
-        include_otc: Optional[bool] = None,
-        params: Optional[Dict[str, Any]] = None,
-    ) -> Dict[str, Any]:
+    market_type: str,
+    direction: str,
+    include_otc: Optional[bool] = None,
+    params: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
     """
     Get gainers or losers for a market.
     """
@@ -415,42 +409,41 @@ async def get_snapshot_direction(
             direction=direction,
             include_otc=include_otc,
             params=params,
-            raw=True
+            raw=True,
         )
-        
-        data_str = results.data.decode('utf-8')
+
+        data_str = results.data.decode("utf-8")
         return json.loads(data_str)
     except Exception as e:
         return {"error": str(e)}
 
+
 @poly_mcp.tool()
 async def get_snapshot_ticker(
-        market_type: str,
-        ticker: str,
-        params: Optional[Dict[str, Any]] = None,
-    ) -> Dict[str, Any]:
+    market_type: str,
+    ticker: str,
+    params: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
     """
     Get snapshot for a specific ticker.
     """
     try:
         results = polygon_client.get_snapshot_ticker(
-            market_type=market_type,
-            ticker=ticker,
-            params=params,
-            raw=True
+            market_type=market_type, ticker=ticker, params=params, raw=True
         )
-        
-        data_str = results.data.decode('utf-8')
+
+        data_str = results.data.decode("utf-8")
         return json.loads(data_str)
     except Exception as e:
         return {"error": str(e)}
 
+
 @poly_mcp.tool()
 async def get_snapshot_option(
-        underlying_asset: str,
-        option_contract: str,
-        params: Optional[Dict[str, Any]] = None,
-    ) -> Dict[str, Any]:
+    underlying_asset: str,
+    option_contract: str,
+    params: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
     """
     Get snapshot for a specific option contract.
     """
@@ -459,86 +452,82 @@ async def get_snapshot_option(
             underlying_asset=underlying_asset,
             option_contract=option_contract,
             params=params,
-            raw=True
+            raw=True,
         )
-        
-        data_str = results.data.decode('utf-8')
+
+        data_str = results.data.decode("utf-8")
         return json.loads(data_str)
     except Exception as e:
         return {"error": str(e)}
 
+
 @poly_mcp.tool()
 async def get_snapshot_crypto_book(
-        ticker: str,
-        params: Optional[Dict[str, Any]] = None,
-    ) -> Dict[str, Any]:
+    ticker: str,
+    params: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
     """
     Get snapshot for a crypto ticker's order book.
     """
     try:
         results = polygon_client.get_snapshot_crypto_book(
-            ticker=ticker,
-            params=params,
-            raw=True
+            ticker=ticker, params=params, raw=True
         )
-        
-        data_str = results.data.decode('utf-8')
+
+        data_str = results.data.decode("utf-8")
         return json.loads(data_str)
     except Exception as e:
         return {"error": str(e)}
 
+
 @poly_mcp.tool()
 async def get_market_holidays(
-        params: Optional[Dict[str, Any]] = None,
-    ) -> Dict[str, Any]:
+    params: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
     """
     Get upcoming market holidays and their open/close times.
     """
     try:
-        results = polygon_client.get_market_holidays(
-            params=params,
-            raw=True
-        )
-        
-        data_str = results.data.decode('utf-8')
+        results = polygon_client.get_market_holidays(params=params, raw=True)
+
+        data_str = results.data.decode("utf-8")
         return json.loads(data_str)
     except Exception as e:
         return {"error": str(e)}
 
+
 @poly_mcp.tool()
 async def get_market_status(
-        params: Optional[Dict[str, Any]] = None,
-    ) -> Dict[str, Any]:
+    params: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
     """
     Get current trading status of exchanges and financial markets.
     """
     try:
-        results = polygon_client.get_market_status(
-            params=params,
-            raw=True
-        )
-        
-        data_str = results.data.decode('utf-8')
+        results = polygon_client.get_market_status(params=params, raw=True)
+
+        data_str = results.data.decode("utf-8")
         return json.loads(data_str)
     except Exception as e:
         return {"error": str(e)}
 
+
 @poly_mcp.tool()
 async def list_tickers(
-        ticker: Optional[str] = None,
-        type: Optional[str] = None,
-        market: Optional[str] = None,
-        exchange: Optional[str] = None,
-        cusip: Optional[str] = None,
-        cik: Optional[str] = None,
-        date: Optional[Union[str, datetime, date]] = None,
-        search: Optional[str] = None,
-        active: Optional[bool] = None,
-        sort: Optional[str] = None,
-        order: Optional[str] = None,
-        limit: Optional[int] = None,
-        params: Optional[Dict[str, Any]] = None,
-    ) -> Dict[str, Any]:
+    ticker: Optional[str] = None,
+    type: Optional[str] = None,
+    market: Optional[str] = None,
+    exchange: Optional[str] = None,
+    cusip: Optional[str] = None,
+    cik: Optional[str] = None,
+    date: Optional[Union[str, datetime, date]] = None,
+    search: Optional[str] = None,
+    active: Optional[bool] = None,
+    sort: Optional[str] = None,
+    order: Optional[str] = None,
+    limit: Optional[int] = None,
+    params: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
     """
     Query supported ticker symbols across stocks, indices, forex, and crypto.
     """
@@ -557,45 +546,44 @@ async def list_tickers(
             order=order,
             limit=limit,
             params=params,
-            raw=True
+            raw=True,
         )
-        
-        data_str = results.data.decode('utf-8')
+
+        data_str = results.data.decode("utf-8")
         return json.loads(data_str)
     except Exception as e:
         return {"error": str(e)}
 
+
 @poly_mcp.tool()
 async def get_ticker_details(
-        ticker: str,
-        date: Optional[Union[str, datetime, date]] = None,
-        params: Optional[Dict[str, Any]] = None,
-    ) -> Dict[str, Any]:
+    ticker: str,
+    date: Optional[Union[str, datetime, date]] = None,
+    params: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
     """
     Get detailed information about a specific ticker.
     """
     try:
         results = polygon_client.get_ticker_details(
-            ticker=ticker,
-            date=date,
-            params=params,
-            raw=True
+            ticker=ticker, date=date, params=params, raw=True
         )
-        
-        data_str = results.data.decode('utf-8')
+
+        data_str = results.data.decode("utf-8")
         return json.loads(data_str)
     except Exception as e:
         return {"error": str(e)}
 
+
 @poly_mcp.tool()
 async def list_ticker_news(
-        ticker: Optional[str] = None,
-        published_utc: Optional[Union[str, datetime, date]] = None,
-        limit: Optional[int] = None,
-        sort: Optional[str] = None,
-        order: Optional[str] = None,
-        params: Optional[Dict[str, Any]] = None,
-    ) -> Dict[str, Any]:
+    ticker: Optional[str] = None,
+    published_utc: Optional[Union[str, datetime, date]] = None,
+    limit: Optional[int] = None,
+    sort: Optional[str] = None,
+    order: Optional[str] = None,
+    params: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
     """
     Get recent news articles for a stock ticker.
     """
@@ -607,44 +595,43 @@ async def list_ticker_news(
             sort=sort,
             order=order,
             params=params,
-            raw=True
+            raw=True,
         )
-        
-        data_str = results.data.decode('utf-8')
+
+        data_str = results.data.decode("utf-8")
         return json.loads(data_str)
     except Exception as e:
         return {"error": str(e)}
 
+
 @poly_mcp.tool()
 async def get_ticker_types(
-        asset_class: Optional[str] = None,
-        locale: Optional[str] = None,
-        params: Optional[Dict[str, Any]] = None,
-    ) -> Dict[str, Any]:
+    asset_class: Optional[str] = None,
+    locale: Optional[str] = None,
+    params: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
     """
     List all ticker types supported by Polygon.io.
     """
     try:
         results = polygon_client.get_ticker_types(
-            asset_class=asset_class,
-            locale=locale,
-            params=params,
-            raw=True
+            asset_class=asset_class, locale=locale, params=params, raw=True
         )
-        
-        data_str = results.data.decode('utf-8')
+
+        data_str = results.data.decode("utf-8")
         return json.loads(data_str)
     except Exception as e:
         return {"error": str(e)}
 
+
 @poly_mcp.tool()
 async def list_splits(
-        ticker: Optional[str] = None,
-        execution_date: Optional[Union[str, datetime, date]] = None,
-        reverse_split: Optional[bool] = None,
-        limit: Optional[int] = None,
-        params: Optional[Dict[str, Any]] = None,
-    ) -> Dict[str, Any]:
+    ticker: Optional[str] = None,
+    execution_date: Optional[Union[str, datetime, date]] = None,
+    reverse_split: Optional[bool] = None,
+    limit: Optional[int] = None,
+    params: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
     """
     Get historical stock splits.
     """
@@ -655,23 +642,24 @@ async def list_splits(
             reverse_split=reverse_split,
             limit=limit,
             params=params,
-            raw=True
+            raw=True,
         )
-        
-        data_str = results.data.decode('utf-8')
+
+        data_str = results.data.decode("utf-8")
         return json.loads(data_str)
     except Exception as e:
         return {"error": str(e)}
 
+
 @poly_mcp.tool()
 async def list_dividends(
-        ticker: Optional[str] = None,
-        ex_dividend_date: Optional[Union[str, datetime, date]] = None,
-        frequency: Optional[int] = None,
-        dividend_type: Optional[str] = None,
-        limit: Optional[int] = None,
-        params: Optional[Dict[str, Any]] = None,
-    ) -> Dict[str, Any]:
+    ticker: Optional[str] = None,
+    ex_dividend_date: Optional[Union[str, datetime, date]] = None,
+    frequency: Optional[int] = None,
+    dividend_type: Optional[str] = None,
+    limit: Optional[int] = None,
+    params: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
     """
     Get historical cash dividends.
     """
@@ -683,22 +671,23 @@ async def list_dividends(
             dividend_type=dividend_type,
             limit=limit,
             params=params,
-            raw=True
+            raw=True,
         )
-        
-        data_str = results.data.decode('utf-8')
+
+        data_str = results.data.decode("utf-8")
         return json.loads(data_str)
     except Exception as e:
         return {"error": str(e)}
 
+
 @poly_mcp.tool()
 async def list_conditions(
-        asset_class: Optional[str] = None,
-        data_type: Optional[str] = None,
-        id: Optional[int] = None,
-        sip: Optional[str] = None,
-        params: Optional[Dict[str, Any]] = None,
-    ) -> Dict[str, Any]:
+    asset_class: Optional[str] = None,
+    data_type: Optional[str] = None,
+    id: Optional[int] = None,
+    sip: Optional[str] = None,
+    params: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
     """
     List conditions used by Polygon.io.
     """
@@ -709,60 +698,59 @@ async def list_conditions(
             id=id,
             sip=sip,
             params=params,
-            raw=True
+            raw=True,
         )
-        
-        data_str = results.data.decode('utf-8')
+
+        data_str = results.data.decode("utf-8")
         return json.loads(data_str)
     except Exception as e:
         return {"error": str(e)}
 
+
 @poly_mcp.tool()
 async def get_exchanges(
-        asset_class: Optional[str] = None,
-        locale: Optional[str] = None,
-        params: Optional[Dict[str, Any]] = None,
-    ) -> Dict[str, Any]:
+    asset_class: Optional[str] = None,
+    locale: Optional[str] = None,
+    params: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
     """
     List exchanges known by Polygon.io.
     """
     try:
         results = polygon_client.get_exchanges(
-            asset_class=asset_class,
-            locale=locale,
-            params=params,
-            raw=True
+            asset_class=asset_class, locale=locale, params=params, raw=True
         )
-        
-        data_str = results.data.decode('utf-8')
+
+        data_str = results.data.decode("utf-8")
         return json.loads(data_str)
     except Exception as e:
         return {"error": str(e)}
 
+
 @poly_mcp.tool()
 async def list_stock_financials(
-        ticker: Optional[str] = None,
-        cik: Optional[str] = None,
-        company_name: Optional[str] = None,
-        company_name_search: Optional[str] = None,
-        sic: Optional[str] = None,
-        filing_date: Optional[Union[str, datetime, date]] = None,
-        filing_date_lt: Optional[Union[str, datetime, date]] = None,
-        filing_date_lte: Optional[Union[str, datetime, date]] = None,
-        filing_date_gt: Optional[Union[str, datetime, date]] = None,
-        filing_date_gte: Optional[Union[str, datetime, date]] = None,
-        period_of_report_date: Optional[Union[str, datetime, date]] = None,
-        period_of_report_date_lt: Optional[Union[str, datetime, date]] = None,
-        period_of_report_date_lte: Optional[Union[str, datetime, date]] = None,
-        period_of_report_date_gt: Optional[Union[str, datetime, date]] = None,
-        period_of_report_date_gte: Optional[Union[str, datetime, date]] = None,
-        timeframe: Optional[str] = None,
-        include_sources: Optional[bool] = None,
-        limit: Optional[int] = None,
-        sort: Optional[str] = None,
-        order: Optional[str] = None,
-        params: Optional[Dict[str, Any]] = None,
-    ) -> Dict[str, Any]:
+    ticker: Optional[str] = None,
+    cik: Optional[str] = None,
+    company_name: Optional[str] = None,
+    company_name_search: Optional[str] = None,
+    sic: Optional[str] = None,
+    filing_date: Optional[Union[str, datetime, date]] = None,
+    filing_date_lt: Optional[Union[str, datetime, date]] = None,
+    filing_date_lte: Optional[Union[str, datetime, date]] = None,
+    filing_date_gt: Optional[Union[str, datetime, date]] = None,
+    filing_date_gte: Optional[Union[str, datetime, date]] = None,
+    period_of_report_date: Optional[Union[str, datetime, date]] = None,
+    period_of_report_date_lt: Optional[Union[str, datetime, date]] = None,
+    period_of_report_date_lte: Optional[Union[str, datetime, date]] = None,
+    period_of_report_date_gt: Optional[Union[str, datetime, date]] = None,
+    period_of_report_date_gte: Optional[Union[str, datetime, date]] = None,
+    timeframe: Optional[str] = None,
+    include_sources: Optional[bool] = None,
+    limit: Optional[int] = None,
+    sort: Optional[str] = None,
+    order: Optional[str] = None,
+    params: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
     """
     Get fundamental financial data for companies.
     """
@@ -789,28 +777,29 @@ async def list_stock_financials(
             sort=sort,
             order=order,
             params=params,
-            raw=True
+            raw=True,
         )
-        
-        data_str = results.data.decode('utf-8')
+
+        data_str = results.data.decode("utf-8")
         return json.loads(data_str)
     except Exception as e:
         return {"error": str(e)}
 
+
 @poly_mcp.tool()
 async def list_ipos(
-        ticker: Optional[str] = None,
-        listing_date: Optional[Union[str, datetime, date]] = None,
-        listing_date_lt: Optional[Union[str, datetime, date]] = None,
-        listing_date_lte: Optional[Union[str, datetime, date]] = None,
-        listing_date_gt: Optional[Union[str, datetime, date]] = None,
-        listing_date_gte: Optional[Union[str, datetime, date]] = None,
-        ipo_status: Optional[str] = None,
-        limit: Optional[int] = None,
-        sort: Optional[str] = None,
-        order: Optional[str] = None,
-        params: Optional[Dict[str, Any]] = None,
-    ) -> Dict[str, Any]:
+    ticker: Optional[str] = None,
+    listing_date: Optional[Union[str, datetime, date]] = None,
+    listing_date_lt: Optional[Union[str, datetime, date]] = None,
+    listing_date_lte: Optional[Union[str, datetime, date]] = None,
+    listing_date_gt: Optional[Union[str, datetime, date]] = None,
+    listing_date_gte: Optional[Union[str, datetime, date]] = None,
+    ipo_status: Optional[str] = None,
+    limit: Optional[int] = None,
+    sort: Optional[str] = None,
+    order: Optional[str] = None,
+    params: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
     """
     Retrieve upcoming or historical IPOs.
     """
@@ -827,27 +816,28 @@ async def list_ipos(
             sort=sort,
             order=order,
             params=params,
-            raw=True
+            raw=True,
         )
-        
-        data_str = results.data.decode('utf-8')
+
+        data_str = results.data.decode("utf-8")
         return json.loads(data_str)
     except Exception as e:
         return {"error": str(e)}
 
+
 @poly_mcp.tool()
 async def list_short_interest(
-        ticker: Optional[str] = None,
-        settlement_date: Optional[Union[str, datetime, date]] = None,
-        settlement_date_lt: Optional[Union[str, datetime, date]] = None,
-        settlement_date_lte: Optional[Union[str, datetime, date]] = None,
-        settlement_date_gt: Optional[Union[str, datetime, date]] = None,
-        settlement_date_gte: Optional[Union[str, datetime, date]] = None,
-        limit: Optional[int] = None,
-        sort: Optional[str] = None,
-        order: Optional[str] = None,
-        params: Optional[Dict[str, Any]] = None,
-    ) -> Dict[str, Any]:
+    ticker: Optional[str] = None,
+    settlement_date: Optional[Union[str, datetime, date]] = None,
+    settlement_date_lt: Optional[Union[str, datetime, date]] = None,
+    settlement_date_lte: Optional[Union[str, datetime, date]] = None,
+    settlement_date_gt: Optional[Union[str, datetime, date]] = None,
+    settlement_date_gte: Optional[Union[str, datetime, date]] = None,
+    limit: Optional[int] = None,
+    sort: Optional[str] = None,
+    order: Optional[str] = None,
+    params: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
     """
     Retrieve short interest data for stocks.
     """
@@ -863,27 +853,28 @@ async def list_short_interest(
             sort=sort,
             order=order,
             params=params,
-            raw=True
+            raw=True,
         )
-        
-        data_str = results.data.decode('utf-8')
+
+        data_str = results.data.decode("utf-8")
         return json.loads(data_str)
     except Exception as e:
         return {"error": str(e)}
 
+
 @poly_mcp.tool()
 async def list_short_volume(
-        ticker: Optional[str] = None,
-        date: Optional[Union[str, datetime, date]] = None,
-        date_lt: Optional[Union[str, datetime, date]] = None,
-        date_lte: Optional[Union[str, datetime, date]] = None,
-        date_gt: Optional[Union[str, datetime, date]] = None,
-        date_gte: Optional[Union[str, datetime, date]] = None,
-        limit: Optional[int] = None,
-        sort: Optional[str] = None,
-        order: Optional[str] = None,
-        params: Optional[Dict[str, Any]] = None,
-    ) -> Dict[str, Any]:
+    ticker: Optional[str] = None,
+    date: Optional[Union[str, datetime, date]] = None,
+    date_lt: Optional[Union[str, datetime, date]] = None,
+    date_lte: Optional[Union[str, datetime, date]] = None,
+    date_gt: Optional[Union[str, datetime, date]] = None,
+    date_gte: Optional[Union[str, datetime, date]] = None,
+    limit: Optional[int] = None,
+    sort: Optional[str] = None,
+    order: Optional[str] = None,
+    params: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
     """
     Retrieve short volume data for stocks.
     """
@@ -899,26 +890,27 @@ async def list_short_volume(
             sort=sort,
             order=order,
             params=params,
-            raw=True
+            raw=True,
         )
-        
-        data_str = results.data.decode('utf-8')
+
+        data_str = results.data.decode("utf-8")
         return json.loads(data_str)
     except Exception as e:
         return {"error": str(e)}
 
+
 @poly_mcp.tool()
 async def list_treasury_yields(
-        date: Optional[Union[str, datetime, date]] = None,
-        date_lt: Optional[Union[str, datetime, date]] = None,
-        date_lte: Optional[Union[str, datetime, date]] = None,
-        date_gt: Optional[Union[str, datetime, date]] = None,
-        date_gte: Optional[Union[str, datetime, date]] = None,
-        limit: Optional[int] = None,
-        sort: Optional[str] = None,
-        order: Optional[str] = None,
-        params: Optional[Dict[str, Any]] = None,
-    ) -> Dict[str, Any]:
+    date: Optional[Union[str, datetime, date]] = None,
+    date_lt: Optional[Union[str, datetime, date]] = None,
+    date_lte: Optional[Union[str, datetime, date]] = None,
+    date_gt: Optional[Union[str, datetime, date]] = None,
+    date_gte: Optional[Union[str, datetime, date]] = None,
+    limit: Optional[int] = None,
+    sort: Optional[str] = None,
+    order: Optional[str] = None,
+    params: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
     """
     Retrieve treasury yield data.
     """
@@ -933,17 +925,19 @@ async def list_treasury_yields(
             sort=sort,
             order=order,
             params=params,
-            raw=True
+            raw=True,
         )
-        
-        data_str = results.data.decode('utf-8')
+
+        data_str = results.data.decode("utf-8")
         return json.loads(data_str)
     except Exception as e:
         return {"error": str(e)}
 
+
 # Directly expose the MCP server object
 # It will be run from entrypoint.py
 
-def run(transport):
+
+def run(transport: Literal["stdio", "sse", "streamable-http"] = "stdio") -> None:
     """Run the Polygon MCP server."""
     poly_mcp.run(transport)

--- a/uv.lock
+++ b/uv.lock
@@ -170,11 +170,19 @@ dependencies = [
     { name = "polygon-api-client" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "ruff" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "mcp", extras = ["cli"], specifier = ">=1.9.3" },
     { name = "polygon-api-client", specifier = ">=1.14.5" },
 ]
+
+[package.metadata.requires-dev]
+dev = [{ name = "ruff", specifier = ">=0.12.4" }]
 
 [[package]]
 name = "mdurl"
@@ -340,6 +348,31 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ab/3a/0316b28d0761c6734d6bc14e770d85506c986c85ffb239e688eeaab2c2bc/rich-13.9.4.tar.gz", hash = "sha256:439594978a49a09530cff7ebc4b5c7103ef57baf48d5ea3184f21d9a2befa098", size = 223149 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/19/71/39c7c0d87f8d4e6c020a393182060eaefeeae6c01dab6a84ec346f2567df/rich-13.9.4-py3-none-any.whl", hash = "sha256:6049d5e6ec054bf2779ab3358186963bac2ea89175919d699e378b99738c2a90", size = 242424 },
+]
+
+[[package]]
+name = "ruff"
+version = "0.12.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9b/ce/8d7dbedede481245b489b769d27e2934730791a9a82765cb94566c6e6abd/ruff-0.12.4.tar.gz", hash = "sha256:13efa16df6c6eeb7d0f091abae50f58e9522f3843edb40d56ad52a5a4a4b6873", size = 5131435 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ae/9f/517bc5f61bad205b7f36684ffa5415c013862dee02f55f38a217bdbe7aa4/ruff-0.12.4-py3-none-linux_armv6l.whl", hash = "sha256:cb0d261dac457ab939aeb247e804125a5d521b21adf27e721895b0d3f83a0d0a", size = 10188824 },
+    { url = "https://files.pythonhosted.org/packages/28/83/691baae5a11fbbde91df01c565c650fd17b0eabed259e8b7563de17c6529/ruff-0.12.4-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:55c0f4ca9769408d9b9bac530c30d3e66490bd2beb2d3dae3e4128a1f05c7442", size = 10884521 },
+    { url = "https://files.pythonhosted.org/packages/d6/8d/756d780ff4076e6dd035d058fa220345f8c458391f7edfb1c10731eedc75/ruff-0.12.4-py3-none-macosx_11_0_arm64.whl", hash = "sha256:a8224cc3722c9ad9044da7f89c4c1ec452aef2cfe3904365025dd2f51daeae0e", size = 10277653 },
+    { url = "https://files.pythonhosted.org/packages/8d/97/8eeee0f48ece153206dce730fc9e0e0ca54fd7f261bb3d99c0a4343a1892/ruff-0.12.4-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e9949d01d64fa3672449a51ddb5d7548b33e130240ad418884ee6efa7a229586", size = 10485993 },
+    { url = "https://files.pythonhosted.org/packages/49/b8/22a43d23a1f68df9b88f952616c8508ea6ce4ed4f15353b8168c48b2d7e7/ruff-0.12.4-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:be0593c69df9ad1465e8a2d10e3defd111fdb62dcd5be23ae2c06da77e8fcffb", size = 10022824 },
+    { url = "https://files.pythonhosted.org/packages/cd/70/37c234c220366993e8cffcbd6cadbf332bfc848cbd6f45b02bade17e0149/ruff-0.12.4-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a7dea966bcb55d4ecc4cc3270bccb6f87a337326c9dcd3c07d5b97000dbff41c", size = 11524414 },
+    { url = "https://files.pythonhosted.org/packages/14/77/c30f9964f481b5e0e29dd6a1fae1f769ac3fd468eb76fdd5661936edd262/ruff-0.12.4-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:afcfa3ab5ab5dd0e1c39bf286d829e042a15e966b3726eea79528e2e24d8371a", size = 12419216 },
+    { url = "https://files.pythonhosted.org/packages/6e/79/af7fe0a4202dce4ef62c5e33fecbed07f0178f5b4dd9c0d2fcff5ab4a47c/ruff-0.12.4-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c057ce464b1413c926cdb203a0f858cd52f3e73dcb3270a3318d1630f6395bb3", size = 11976756 },
+    { url = "https://files.pythonhosted.org/packages/09/d1/33fb1fc00e20a939c305dbe2f80df7c28ba9193f7a85470b982815a2dc6a/ruff-0.12.4-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e64b90d1122dc2713330350626b10d60818930819623abbb56535c6466cce045", size = 11020019 },
+    { url = "https://files.pythonhosted.org/packages/64/f4/e3cd7f7bda646526f09693e2e02bd83d85fff8a8222c52cf9681c0d30843/ruff-0.12.4-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2abc48f3d9667fdc74022380b5c745873499ff827393a636f7a59da1515e7c57", size = 11277890 },
+    { url = "https://files.pythonhosted.org/packages/5e/d0/69a85fb8b94501ff1a4f95b7591505e8983f38823da6941eb5b6badb1e3a/ruff-0.12.4-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:2b2449dc0c138d877d629bea151bee8c0ae3b8e9c43f5fcaafcd0c0d0726b184", size = 10348539 },
+    { url = "https://files.pythonhosted.org/packages/16/a0/91372d1cb1678f7d42d4893b88c252b01ff1dffcad09ae0c51aa2542275f/ruff-0.12.4-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:56e45bb11f625db55f9b70477062e6a1a04d53628eda7784dce6e0f55fd549eb", size = 10009579 },
+    { url = "https://files.pythonhosted.org/packages/23/1b/c4a833e3114d2cc0f677e58f1df6c3b20f62328dbfa710b87a1636a5e8eb/ruff-0.12.4-py3-none-musllinux_1_2_i686.whl", hash = "sha256:478fccdb82ca148a98a9ff43658944f7ab5ec41c3c49d77cd99d44da019371a1", size = 10942982 },
+    { url = "https://files.pythonhosted.org/packages/ff/ce/ce85e445cf0a5dd8842f2f0c6f0018eedb164a92bdf3eda51984ffd4d989/ruff-0.12.4-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:0fc426bec2e4e5f4c4f182b9d2ce6a75c85ba9bcdbe5c6f2a74fcb8df437df4b", size = 11343331 },
+    { url = "https://files.pythonhosted.org/packages/35/cf/441b7fc58368455233cfb5b77206c849b6dfb48b23de532adcc2e50ccc06/ruff-0.12.4-py3-none-win32.whl", hash = "sha256:4de27977827893cdfb1211d42d84bc180fceb7b72471104671c59be37041cf93", size = 10267904 },
+    { url = "https://files.pythonhosted.org/packages/ce/7e/20af4a0df5e1299e7368d5ea4350412226afb03d95507faae94c80f00afd/ruff-0.12.4-py3-none-win_amd64.whl", hash = "sha256:fe0b9e9eb23736b453143d72d2ceca5db323963330d5b7859d60d101147d461a", size = 11209038 },
+    { url = "https://files.pythonhosted.org/packages/11/02/8857d0dfb8f44ef299a5dfd898f673edefb71e3b533b3b9d2db4c832dd13/ruff-0.12.4-py3-none-win_arm64.whl", hash = "sha256:0618ec4442a83ab545e5b71202a5c0ed7791e8471435b94e655b570a5031a98e", size = 10469336 },
 ]
 
 [[package]]


### PR DESCRIPTION
Adds a [justfile](https://github.com/casey/just) with a recipe for linting using `ruff` and a Github action for ensuring PRs have been linted properly.

This also fixes an issue where `uv run entrypoint.py` and `npx @modelcontextprotocol/inspector uv run entrypoint.py` would fail due to the argument being passed to the `server.run` function.